### PR TITLE
Adding table message type

### DIFF
--- a/strands_perception_msgs/CMakeLists.txt
+++ b/strands_perception_msgs/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(strands_perception_msgs)
+
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs geometry_msgs)
+
+add_message_files(
+  FILES
+  Table.msg
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  geometry_msgs
+)
+catkin_package(
+)
+

--- a/strands_perception_msgs/msg/Table.msg
+++ b/strands_perception_msgs/msg/Table.msg
@@ -1,0 +1,8 @@
+# The location and size of a table
+
+
+Header header 
+
+geometry_msgs/PoseWithCovariance pose			# Pose of the table in the frame given in the header.
+geometry_msgs/Polygon			 tabletop
+string							 table_id

--- a/strands_perception_msgs/package.xml
+++ b/strands_perception_msgs/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>strands_perception_msgs</name>
+  <version>0.0.1</version>
+  <description>Package containing perception message and service definitions.</description>
+
+  <maintainer email="cburbridge@gmail.com">Chris Burbridge</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">TODO</url>
+
+  <author email="cburbridge@gmail.com">Chris Burbridge</author>
+  
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+
+  <run_depend>std_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+
+  <export/>
+</package>


### PR DESCRIPTION
This adds a package "strands_perception_msgs", and a  Table.msg definition.

Tables are defined by a transformation from the header frame to the table frame, a table id string, and a polygon in the table frame. The polygon represents the table top.
