### PR TITLE
Removed `topological_utils` from memory_game_msgs dependencies. Not needed any more.

### DIFF
--- a/memory_game_msgs/CMakeLists.txt
+++ b/memory_game_msgs/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
     actionlib
     genmsg
     actionlib_msgs
-    topological_utils
 )
 
 add_message_files(
@@ -37,7 +36,6 @@ generate_messages(
   std_msgs
   geometry_msgs
   actionlib_msgs
-  topological_utils
 )
 
 catkin_package(

--- a/memory_game_msgs/package.xml
+++ b/memory_game_msgs/package.xml
@@ -17,11 +17,13 @@
   <build_depend>message_generation</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>genmsg</build_depend>
 
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
-
+  <run_depend>genmsg</run_depend>
+  
   <export/>
 </package>


### PR DESCRIPTION
Fixing: https://github.com/strands-project/memory_game/issues/86
