### PR TITLE
added information to monitored navigation action result

### DIFF
--- a/strands_navigation_msgs/action/MonitoredNavigation.action
+++ b/strands_navigation_msgs/action/MonitoredNavigation.action
@@ -1,4 +1,10 @@
 string action_server
 geometry_msgs/PoseStamped target_pose
 ---
+uint8 SUCCEEDED=0
+uint8 BUMPER_FAILURE=1
+uint8 LOCAL_PLANNER_FAILURE=2
+uint8 GLOBAL_PLANNER_FAILURE=3
+uint8 PREEMPTED=4
+uint8 sm_outcome
 ---


### PR DESCRIPTION
SUCCEEDED and PREEMPTED are redundant info as they are also present in the action status but I put it in for completeness. There are different types of failures, with GLOBAL_PLANNER_FAILURE meaning that the goal is blocked by an object.
