### PR TITLE
Adding a logging message to the people_perception_msgs

### DIFF
--- a/strands_perception_people_msgs/CMakeLists.txt
+++ b/strands_perception_people_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ add_message_files(
   PedestrianTrackingArray.msg
   PedestrianLocations.msg
   HeadOrientations.msg
+  Logging.msg
 )
 
 # Generate services in the 'srv' folder

--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -1,12 +1,12 @@
-std_msgs/Header header
-int32[] ids
-geometry_msgs/Pose[] people
-geometry_msgs/Pose robot
-float64[] scores
-float64[] distances
-float64[] angles
-float64 min_distance
-float64 min_distance_angle
-PedestrianTracking[] pedestrian_tracking
-UpperBodyDetector upper_body_detections
-geometry_msgs/Transform tf
+std_msgs/Header header #The header taken from the pedestrian localosation msg
+int32[] ids #Unique person id. Reset to 0 on restart of tracker
+geometry_msgs/Pose[] people #The real world poses of the detected people in the given target frame. Default: /base_link. Array index matches ids array index
+geometry_msgs/Pose robot #The last received robot pose
+float64[] scores #The confidence score of the tracker. Array index matches ids array index.
+float64[] distances #The distances of the detected persons to the robot (polar coordinates). Array index matches ids array index.
+float64[] angles #Angles of the detected persons to the coordinate frames z axis (polar coordinates). Array index matches ids array index.
+float64 min_distance #The minimal distance in the distances array.
+float64 min_distance_angle #The angle according to the minimal distance.
+PedestrianTracking[] pedestrian_tracking #Output of the pedestrian tracker
+UpperBodyDetector upper_body_detections #Ouput of the upper body detector
+geometry_msgs/Transform tf #The transformation used to optain real world coordinates of detections

--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -7,3 +7,5 @@ float64[] distances
 float64[] angles
 float64 min_distance
 float64 min_distance_angle
+PedestrianTracking[] pedestrian_tracking
+UpperBodyDetector upper_body_detections

--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -9,3 +9,4 @@ float64 min_distance
 float64 min_distance_angle
 PedestrianTracking[] pedestrian_tracking
 UpperBodyDetector upper_body_detections
+geometry_msgs/Transform tf

--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -1,0 +1,9 @@
+std_msgs/Header header
+int32[] ids
+geometry_msgs/Pose[] people
+geometry_msgs/Pose robot
+float64[] scores
+float64[] distances
+float64[] angles
+float64 min_distance
+float64 min_distance_angle

--- a/strands_perception_people_msgs/msg/PedestrianLocations.msg
+++ b/strands_perception_people_msgs/msg/PedestrianLocations.msg
@@ -1,6 +1,7 @@
 std_msgs/Header header
 int32[] ids
 geometry_msgs/Pose[] poses
+float64[] scores
 float64[] distances
 float64[] angles
 float64 min_distance


### PR DESCRIPTION
This is used to combine a lot of the gathered information together with the robot pose in one message in the message_store.
- Does not change the normal behaviour of the tracker.
- The localisation node is now also publishing the score (confidence) of the tracker.

Tested on Linda.
