### PR TITLE
Changed ids array to a string array to accommodate the uuid.

### DIFF
--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -1,5 +1,5 @@
 std_msgs/Header header #The header taken from the pedestrian localosation msg
-int32[] ids #Unique person id. Reset to 0 on restart of tracker
+string[] ids #Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and tracker id.
 geometry_msgs/Pose[] people #The real world poses of the detected people in the given target frame. Default: /base_link. Array index matches ids array index
 geometry_msgs/Pose robot #The last received robot pose
 float64[] scores #The confidence score of the tracker. Array index matches ids array index.


### PR DESCRIPTION
In order to ease the re-identification of detected persons, I changed the ids int array to a string array to accommodate a uuid5 unique id.
