### PR TITLE
Unique uuids for every module of the ppl perception pipeline that uses ids

### DIFF
--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -4,7 +4,7 @@ string[] uuids                             # Unique uuid5 (NAMESPACE_DNS) person
 geometry_msgs/Pose[] people                # The real world poses of the detected people in the given target frame. Default: /map. Array index matches ids/uuids array index
 geometry_msgs/Pose robot                   # The last received robot pose
 float64[] scores                           # The confidence score of the tracker. Array index matches ids/uuids array index.
-PedestrianLocations[] pedestrian_locations # Output of the pedestrian localisation
+PedestrianLocations pedestrian_locations # Output of the pedestrian localisation
 PedestrianTracking[] pedestrian_tracking   # Output of the pedestrian tracker
 UpperBodyDetector upper_body_detections    # Ouput of the upper body detector
 geometry_msgs/Transform target_frame       # The transformation used to optain real world coordinates of detections. Default /map

--- a/strands_perception_people_msgs/msg/Logging.msg
+++ b/strands_perception_people_msgs/msg/Logging.msg
@@ -1,12 +1,11 @@
-std_msgs/Header header #The header taken from the pedestrian localosation msg
-string[] ids #Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and tracker id.
-geometry_msgs/Pose[] people #The real world poses of the detected people in the given target frame. Default: /base_link. Array index matches ids array index
-geometry_msgs/Pose robot #The last received robot pose
-float64[] scores #The confidence score of the tracker. Array index matches ids array index.
-float64[] distances #The distances of the detected persons to the robot (polar coordinates). Array index matches ids array index.
-float64[] angles #Angles of the detected persons to the coordinate frames z axis (polar coordinates). Array index matches ids array index.
-float64 min_distance #The minimal distance in the distances array.
-float64 min_distance_angle #The angle according to the minimal distance.
-PedestrianTracking[] pedestrian_tracking #Output of the pedestrian tracker
-UpperBodyDetector upper_body_detections #Ouput of the upper body detector
-geometry_msgs/Transform tf #The transformation used to optain real world coordinates of detections
+std_msgs/Header header
+int64[] ids                                # Tracker ids
+string[] uuids                             # Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and tracker id. Array index matches ids array index
+geometry_msgs/Pose[] people                # The real world poses of the detected people in the given target frame. Default: /map. Array index matches ids/uuids array index
+geometry_msgs/Pose robot                   # The last received robot pose
+float64[] scores                           # The confidence score of the tracker. Array index matches ids/uuids array index.
+PedestrianLocations[] pedestrian_locations # Output of the pedestrian localisation
+PedestrianTracking[] pedestrian_tracking   # Output of the pedestrian tracker
+UpperBodyDetector upper_body_detections    # Ouput of the upper body detector
+geometry_msgs/Transform target_frame       # The transformation used to optain real world coordinates of detections. Default /map
+geometry_msgs/Transform base_link          # The transformation used to optain distances and angles relative to the robot. /head_xtion_depth_optical_frame to /base_link

--- a/strands_perception_people_msgs/msg/PedestrianLocations.msg
+++ b/strands_perception_people_msgs/msg/PedestrianLocations.msg
@@ -1,8 +1,9 @@
 std_msgs/Header header
-int32[] ids
-geometry_msgs/Pose[] poses
-float64[] scores
-float64[] distances
-float64[] angles
-float64 min_distance
-float64 min_distance_angle
+int32[] ids                # Tracker ids
+string[] uuids             # Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and tracker id. Array index matches ids array index
+geometry_msgs/Pose[] poses # The real world poses of the detected people in the given target frame. Default: /map. Array index matches ids/uuids array index
+float64[] scores           # The confidence score of the tracker. Array index matches ids/uuids array index.
+float64[] distances        # The distances of the detected persons to the robot (polar coordinates). Array index matches ids array index.
+float64[] angles           # Angles of the detected persons to the coordinate frames z axis (polar coordinates). Array index matches ids array index.
+float64 min_distance       # The minimal distance in the distances array.
+float64 min_distance_angle # The angle according to the minimal distance.

--- a/strands_perception_people_msgs/msg/PedestrianTracking.msg
+++ b/strands_perception_people_msgs/msg/PedestrianTracking.msg
@@ -9,5 +9,6 @@ float64[] traj_y_camera
 float64[] traj_z_camera 
 float64[] dir 	
 float64 speed 	
-int64 id  
+int64 id
+string uuid #Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and id.
 float64 score

--- a/strands_perception_people_msgs/msg/PedestrianTracking.msg
+++ b/strands_perception_people_msgs/msg/PedestrianTracking.msg
@@ -7,8 +7,8 @@ float64[] traj_z
 float64[] traj_x_camera 
 float64[] traj_y_camera 
 float64[] traj_z_camera 
-float64[] dir 	
-float64 speed 	
-int64 id
-string uuid #Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and id.
-float64 score
+float64[] dir           # Orientation of person for every point in traj
+float64 speed           # Speed of detected person
+int64 id                # Tracking id. Will be reset to 0 after restart
+string uuid             # Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and id.
+float64 score           # Tracker confidence


### PR DESCRIPTION
The tracker, the localisations, and the logger now all use the same uuid to easily associate them. See: https://github.com/strands-project/strands_perception_people/issues/72 which requires these messages to be updated.

Also added some comments and the Logging messages now contains the whole PedestrianLocalisation message but the poses and ids are still on the top level to allow easier usage.
